### PR TITLE
Fix codecov upload in CI file

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [ '1.19', '1.21' ]
+        go-version: [ '1.21' ]
         os: [ ubuntu-latest, macos-latest ]
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,5 +38,8 @@ jobs:
     - name: Test
       run: go test -v -coverprofile coverage.txt -covermode atomic ./...
 
-    - name: Coverage
-      uses: codecov/codecov-action@v2.1.0
+    - name: Upload coverage reports to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        verbose: true

--- a/doc.go
+++ b/doc.go
@@ -9,6 +9,7 @@ This package supports most Unix-based operating systems. It should work fine
 on MacOS.
 
 Usage
+
 	package main
 
 	import (


### PR DESCRIPTION
- Removed Go version 1.19 from CI file
- Fixed codecov upload action in CI file
- Added blank line in docs for xdg
